### PR TITLE
Fix bad TLS cert in plain text auth

### DIFF
--- a/azrcrv-smtp.php
+++ b/azrcrv-smtp.php
@@ -578,14 +578,15 @@ function azrcrv_smtp_send_test_email(){
 		
 		$phpmailer->Host = $options['smtp-host'];
 		$phpmailer->Port = $options['smtp-port'];
-		if ($options['smtp-encryption-type'] == 'none'){
-			$phpmailer->SMTPAuth = false;
-		}else{
-			$phpmailer->SMTPAuth = true;
+
+		if ($options['smtp-encryption-type'] !== 'none'){
 			$phpmailer->SMTPSecure = $options['smtp-encryption-type'];
 		}
 		$phpmailer->Username = $options['smtp-username'];
 		$phpmailer->Password = $options['smtp-password'];
+		
+		// Don't authenticate if username is left empty
+		$phpmailer->SMTPAuth = $options['smtp-encryption-type'] !== '';
 		
 		if (strlen($options['from-email-address']) > 0){
 			$phpmailer->From = $options['from-email-address'];
@@ -602,6 +603,9 @@ function azrcrv_smtp_send_test_email(){
 		$phpmailer->SMTPDebug = 1;
 		$phpmailer->Debugoutput = function($str, $level){ $error .= $level.': '.$str.'\n';};
 		
+		// Don't fail if the server is advertising TLS with an invalid certificate
+		$phpmailer->SMTPAutoTLS = false;
+
 		if ($phpmailer->send()) {
 			$result = 'test-email&status=sent';
 		} else {
@@ -635,14 +639,16 @@ function azrcrv_smtp_send_smtp_email($phpmailer){
 	$phpmailer->isSMTP();
 	$phpmailer->Host = $options['smtp-host'];
 	$phpmailer->Port = $options['smtp-port'];
-	if ($options['smtp-encryption-type'] == 'none'){
-		$phpmailer->SMTPAuth = false;
-	}else{
-		$phpmailer->SMTPAuth = true;
+	if ($options['smtp-encryption-type'] !== 'none'){
 		$phpmailer->SMTPSecure = $options['smtp-encryption-type'];
 	}
 	$phpmailer->Username = $options['smtp-username'];
 	$phpmailer->Password = $options['smtp-password'];
+	
+	// Don't authenticate if username is left empty
+	$phpmailer->SMTPAuth = $options['smtp-encryption-type'] !== '';
+	// Don't fail if the server is advertising TLS with an invalid certificate
+	$phpmailer->SMTPAutoTLS = false;
 	
 	if (strlen($options['from-email-address']) > 0){
     	$phpmailer->From = $options['from-email-address'];


### PR DESCRIPTION
I wasn't able to use the plugin with a (weired i think) SMTP server.

This PR tries to fix:
1. If a server advertise TSL with a wrong cert it results in an error
2. Even if SMTP EncryptionType is none you may want to authenticate

You may want to add a checkbox for the second point. With this PR there is no auth if username is left empty.