### PR TITLE
Import from Easy WP SMTP

### DIFF
--- a/assets/jquery/jquery.js
+++ b/assets/jquery/jquery.js
@@ -14,10 +14,7 @@ jQuery(document).ready(function() {
 
 jQuery(function($) {
 	$(document).on('click', '.azrcrv-smtp-import-dismiss', function () {
-		// Read the "data-notice" information to track which notice
-		// is being dismissed and send it via AJAX
 		var nonce = $(this).closest('.azrcrv-smtp-import-dismiss').data('nonce');
-		console.log(nonce)
 		$.ajax( ajaxurl,
 			{
 				type: 'POST',

--- a/assets/jquery/jquery.js
+++ b/assets/jquery/jquery.js
@@ -11,3 +11,20 @@ jQuery(document).ready(function() {
 	});
 	
 });
+
+jQuery(function($) {
+	$(document).on('click', '.azrcrv-smtp-import-dismiss', function () {
+		// Read the "data-notice" information to track which notice
+		// is being dismissed and send it via AJAX
+		var nonce = $(this).closest('.azrcrv-smtp-import-dismiss').data('nonce');
+		console.log(nonce)
+		$.ajax( ajaxurl,
+			{
+				type: 'POST',
+				data: {
+					action: 'azrcrv_smtp_import_dismiss',
+					nonce: nonce,
+			}
+		  } );
+	  } );
+});

--- a/azrcrv-smtp.php
+++ b/azrcrv-smtp.php
@@ -40,6 +40,7 @@ use PHPMailer\PHPMailer\Exception;
  *
  */
 // add actions
+register_activation_hook(__FILE__, 'azrcrv_smtp_activate');
 add_action('admin_menu', 'azrcrv_smtp_create_admin_menu');
 add_action('admin_enqueue_scripts', 'azrcrv_smtp_load_admin_style');
 add_action('admin_post_azrcrv_smtp_save_options', 'azrcrv_smtp_save_options');
@@ -51,6 +52,101 @@ add_action('phpmailer_init', 'azrcrv_smtp_send_smtp_email');
 add_filter('plugin_action_links', 'azrcrv_smtp_add_plugin_action_link', 10, 2);
 add_filter('codepotent_update_manager_image_path', 'azrcrv_smtp_custom_image_path');
 add_filter('codepotent_update_manager_image_url', 'azrcrv_smtp_custom_image_url');
+
+function azrcrv_smtp_activate() {
+
+	// Exit if the options are already in place
+	$my_options = get_option('azrcrv-smtp', false);
+	if ($my_options !== false) {
+		return;
+	}
+
+	// Exit if swpsmtp_options are missing
+	$swpsmtp_options = get_option('swpsmtp_options', false);
+	if ($swpsmtp_options === false) {
+		return;
+	}
+	
+	// Fine... we have settings
+
+	// Exit if password encrypted and openssl missing (possible?)
+	if (isset($swpsmtp_options['smtp_settings']['encrypt_pass']) && $swpsmtp_options['smtp_settings']['encrypt_pass'] === 1 && !extension_loaded('openssl')) {
+		return;
+	}
+	
+	$raw_password = base64_decode($swpsmtp_options['smtp_settings']['password'], true);
+
+	// Exit on failed Base64 decode
+	if ($raw_password === false) {
+		return;
+	}
+
+	// Decrypt password
+	if ($swpsmtp_options['smtp_settings']['encrypt_pass'] === 1) {
+		// Exit if encryption key is missing	
+		$key = get_option('swpsmtp_enc_key');
+		if ($key === false) {
+			return false;
+		}
+		$iv_num_bytes = openssl_cipher_iv_length('aes-256-ctr');
+		$iv	          = substr($raw_password, 0, $iv_num_bytes);
+		$data	      = substr($raw_password, $iv_num_bytes);
+		$keyhash      = openssl_digest($key, 'sha256', true);
+		$password     = openssl_decrypt($data, 'aes-256-ctr', $keyhash, OPENSSL_RAW_DATA, $iv);
+		// Exit on decrypt error
+		if ($password === false) {
+			return false;
+		}
+	} else {
+		$password = $raw_password;
+	}
+
+
+	// Check that everything is defined in swpsmtp_options
+	$swpsmtp_options_default = array(
+						'from_email_field' 	=> '',
+						'from_name_field' 	=> '',
+						'smtp_settings' 	=> array(
+													'host' 				=> '',
+													'type_encryption'	=> '',		
+													'port'				=> '',
+													'username'			=> '',		
+													'autentication'		=> 0,		
+												),
+									);
+		
+	$swpsmtp_options = wp_parse_args($swpsmtp_options, $swpsmtp_options_default);
+
+	// Get test e-mail options
+	$smtp_test_mail_defaults = array(
+						'swpsmtp_to'				=> '',
+						'swpsmtp_subject'			=> '',
+						'swpsmtp_message'			=> '',
+						);
+	
+	$smtp_test_mail = get_option('smtp_test_mail', smtp_test_mail_defaults);
+	$smtp_test_mail = wp_parse_args($smtp_test_mail, $smtp_test_mail_defaults);
+
+	// Create config and save
+	$import = array(
+						'smtp-host' 				=> $swpsmtp_options['smtp_settings']['host'],
+						'smtp-encryption-type' 		=> $swpsmtp_options['smtp_settings']['type_encryption'],
+						'smtp-port' 				=> $swpsmtp_options['smtp_settings']['port'],
+						'smtp-username' 			=> $swpsmtp_options['smtp_settings']['username'],
+						'smtp-password' 			=> $password,
+						'allow-no-authentication' 	=> ($swpsmtp_options['smtp_settings']['autentication'] === 'yes' ) ? 0 : 1,
+						'from-email-address' 		=> $swpsmtp_options['from_email_field'],
+						'from-email-name' 			=> $swpsmtp_options['from_name_field'],
+						'test-email-address' 		=> $smtp_test_mail['swpsmtp_to'],
+						'test-email-subject' 		=> $smtp_test_mail['swpsmtp_subject'],
+						'test-email-message' 		=> $smtp_test_mail['swpsmtp_message'],
+					);	
+
+	update_option('azrcrv-smtp', $import);
+	
+	// Set temporary options for imported settings.
+	update_option('azrcrv-smtp-imported', 'Easy WP SMTP');
+}
 
 /**
  * Load language files.
@@ -251,8 +347,19 @@ function azrcrv_smtp_display_options(){
 	<div id="azrcrv-smtp-general" class="wrap">
 		<fieldset>
 			<h1><?php echo esc_html(get_admin_page_title()); ?></h1>
-			
-			<?php if(isset($_GET['settings-updated'])){ ?>
+			<?php if($options['smtp-host'] === '' && ($settings_imported_from = get_option('azrcrv-smtp-imported', false)) !== false){ ?>
+				<div class="notice notice-info is-dismissible">
+					<p><strong><?php 
+					// Display notice about imported settings
+					/* Translators: %s is the plugin where settings were imported from */ 
+					printf(esc_html__('Found %1$s settings that were used to set your defaults.', 'smtp'), $settings_imported_from); 
+					// ... just once
+					delete_option('azrcrv-smtp-imported');
+					?>
+					</strong></p>
+				</div>
+			<?php }
+					if(isset($_GET['settings-updated'])){ ?>
 				<div class="notice notice-success is-dismissible">
 					<p><strong><?php esc_html_e('Settings have been saved.', 'smtp'); ?></strong></p>
 				</div>

--- a/azrcrv-smtp.php
+++ b/azrcrv-smtp.php
@@ -69,8 +69,23 @@ function azrcrv_smtp_activate() {
 	
 	// Fine... we have settings
 
+	// Check that everything is defined in swpsmtp_options
+	$swpsmtp_options_default = array(
+						'from_email_field' 	=> '',
+						'from_name_field' 	=> '',
+						'smtp_settings' 	=> array(
+													'host' 				=> '',
+													'type_encryption'	=> 'SSL',		
+													'port'				=> '465',
+													'username'			=> '',		
+													'autentication'		=> 0,
+													'encrypt_pass'		=> 0,
+												),
+									);
+		
+
 	// Exit if password encrypted and openssl missing (possible?)
-	if (isset($swpsmtp_options['smtp_settings']['encrypt_pass']) && $swpsmtp_options['smtp_settings']['encrypt_pass'] === 1 && !extension_loaded('openssl')) {
+	if ($swpsmtp_options['smtp_settings']['encrypt_pass'] === 1 && !extension_loaded('openssl')) {
 		return;
 	}
 	
@@ -101,22 +116,6 @@ function azrcrv_smtp_activate() {
 		$password = $raw_password;
 	}
 
-
-	// Check that everything is defined in swpsmtp_options
-	$swpsmtp_options_default = array(
-						'from_email_field' 	=> '',
-						'from_name_field' 	=> '',
-						'smtp_settings' 	=> array(
-													'host' 				=> '',
-													'type_encryption'	=> '',		
-													'port'				=> '',
-													'username'			=> '',		
-													'autentication'		=> 0,		
-												),
-									);
-		
-	$swpsmtp_options = wp_parse_args($swpsmtp_options, $swpsmtp_options_default);
-
 	// Get test e-mail options
 	$smtp_test_mail_defaults = array(
 						'swpsmtp_to'				=> '',
@@ -124,7 +123,7 @@ function azrcrv_smtp_activate() {
 						'swpsmtp_message'			=> '',
 						);
 	
-	$smtp_test_mail = get_option('smtp_test_mail', smtp_test_mail_defaults);
+	$smtp_test_mail = get_option('smtp_test_mail', $smtp_test_mail_defaults);
 	$smtp_test_mail = wp_parse_args($smtp_test_mail, $smtp_test_mail_defaults);
 
 	// Create config and save

--- a/azrcrv-smtp.php
+++ b/azrcrv-smtp.php
@@ -780,7 +780,7 @@ function azrcrv_smtp_send_test_email(){
 	
 }
 
-
+// Handle click on import
 function azrcrv_smtp_import_options(){
 
 	if (!current_user_can('manage_options') || !isset($_REQUEST['azrcrv_smtp_import_nonce']) || !wp_verify_nonce($_REQUEST['azrcrv_smtp_import_nonce'], 'azrcrv_smtp_import_nonce')){
@@ -795,6 +795,7 @@ function azrcrv_smtp_import_options(){
 
 }
 
+// Handle AJAX notice dismiss
 function azrcrv_smtp_import_dismiss() {
 	if (!wp_doing_ajax() || !isset($_POST['nonce']) || !wp_verify_nonce($_POST['nonce'], 'azrcrv_smtp_import_dismiss_nonce')){
 		wp_die(esc_html__('You do not have permissions to perform this action', 'smtp'));

--- a/azrcrv-smtp.php
+++ b/azrcrv-smtp.php
@@ -46,7 +46,7 @@ add_action('admin_enqueue_scripts', 'azrcrv_smtp_load_admin_style');
 add_action('admin_post_azrcrv_smtp_save_options', 'azrcrv_smtp_save_options');
 add_action('admin_post_azrcrv_smtp_send_test_email', 'azrcrv_smtp_send_test_email');
 add_action('admin_action_azrcrv_smtp_import_options', 'azrcrv_smtp_import_options');
-//add_action('admin_post_azrcrv_smtp_send_test_email', 'azrcrv_smtp_send_test_email');
+add_action('wp_ajax_azrcrv_smtp_import_dismiss', 'azrcrv_smtp_import_dismiss');
 
 add_action('plugins_loaded', 'azrcrv_smtp_load_languages');
 add_action('phpmailer_init', 'azrcrv_smtp_send_smtp_email');
@@ -364,7 +364,7 @@ function azrcrv_smtp_display_options(){
 		<fieldset>
 			<h1><?php echo esc_html(get_admin_page_title()); ?></h1>
 			<?php if($options['smtp-host'] === '' && get_option('azrcrv-smtp-maybe', false) !== false){ ?>
-				<div class="notice notice-info is-dismissible">
+				<div class="notice notice-info is-dismissible azrcrv-smtp-import-dismiss" data-nonce="<?php echo wp_create_nonce('azrcrv_smtp_import_dismiss_nonce')?>">
 					<p><strong><?php 
 					// Display notice about imported settings
 					$url=remove_query_arg('page');
@@ -793,6 +793,14 @@ function azrcrv_smtp_import_options(){
 	wp_redirect(add_query_arg('page', 'azrcrv-smtp&settings-updated', admin_url('admin.php')));
 	exit;
 
+}
+
+function azrcrv_smtp_import_dismiss() {
+	if (!wp_doing_ajax() || !isset($_POST['nonce']) || !wp_verify_nonce($_POST['nonce'], 'azrcrv_smtp_import_dismiss_nonce')){
+		wp_die(esc_html__('You do not have permissions to perform this action', 'smtp'));
+	}
+	delete_option('azrcrv-smtp-maybe');
+	wp_send_json_success(['Dismissed'=>'Yes']);
 }
 
 /**

--- a/azrcrv-smtp.php
+++ b/azrcrv-smtp.php
@@ -53,6 +53,20 @@ add_filter('plugin_action_links', 'azrcrv_smtp_add_plugin_action_link', 10, 2);
 add_filter('codepotent_update_manager_image_path', 'azrcrv_smtp_custom_image_path');
 add_filter('codepotent_update_manager_image_url', 'azrcrv_smtp_custom_image_url');
 
+function azrcrv_smtp_recursive_merge(&$a, $b) {
+	$a = (array) $a;
+	$b = (array) $b;
+	$result = $b;
+	foreach ($a as $k => &$v) {
+		if (is_array( $v ) && isset($result[$k])) {
+			$result[$k] = azrcrv_smtp_recursive_merge($v, $result[$k]);
+		} else {
+			$result[$k] = $v;
+		}
+	}
+	return $result;
+}
+
 function azrcrv_smtp_activate() {
 
 	// Exit if the options are already in place
@@ -82,7 +96,7 @@ function azrcrv_smtp_activate() {
 													'encrypt_pass'		=> 0,
 												),
 									);
-	$swpsmtp_options = wp_parse_args($swpsmtp_options, $swpsmtp_options_default);		
+	$swpsmtp_options = azrcrv_smtp_recursive_merge($swpsmtp_options, $swpsmtp_options_default);		
 
 	// Exit if password encrypted and openssl missing (possible?)
 	if ($swpsmtp_options['smtp_settings']['encrypt_pass'] === 1 && !extension_loaded('openssl')) {
@@ -346,7 +360,7 @@ function azrcrv_smtp_display_options(){
 	<div id="azrcrv-smtp-general" class="wrap">
 		<fieldset>
 			<h1><?php echo esc_html(get_admin_page_title()); ?></h1>
-			<?php if($options['smtp-host'] === '' && ($settings_imported_from = get_option('azrcrv-smtp-imported', false)) !== false){ ?>
+			<?php if($options['smtp-host'] !== '' && ($settings_imported_from = get_option('azrcrv-smtp-imported', false)) !== false){ ?>
 				<div class="notice notice-info is-dismissible">
 					<p><strong><?php 
 					// Display notice about imported settings

--- a/azrcrv-smtp.php
+++ b/azrcrv-smtp.php
@@ -53,6 +53,8 @@ add_filter('plugin_action_links', 'azrcrv_smtp_add_plugin_action_link', 10, 2);
 add_filter('codepotent_update_manager_image_path', 'azrcrv_smtp_custom_image_path');
 add_filter('codepotent_update_manager_image_url', 'azrcrv_smtp_custom_image_url');
 
+
+// Function needed because wp_parse_args() is not recursive
 function azrcrv_smtp_recursive_merge(&$a, $b) {
 	$a = (array) $a;
 	$b = (array) $b;
@@ -113,7 +115,7 @@ function azrcrv_smtp_activate() {
 	// Decrypt password
 	if ($swpsmtp_options['smtp_settings']['encrypt_pass'] === 1) {
 		// Exit if encryption key is missing	
-		$key = get_option('swpsmtp_enc_key');
+		$key = get_option('swpsmtp_enc_key', false);
 		if ($key === false) {
 			return false;
 		}
@@ -155,6 +157,7 @@ function azrcrv_smtp_activate() {
 						'test-email-message' 		=> $smtp_test_mail['swpsmtp_message'],
 					);	
 
+	// Save options
 	update_option('azrcrv-smtp', $import);
 	
 	// Set temporary options for imported settings.

--- a/azrcrv-smtp.php
+++ b/azrcrv-smtp.php
@@ -82,7 +82,7 @@ function azrcrv_smtp_activate() {
 													'encrypt_pass'		=> 0,
 												),
 									);
-		
+	$swpsmtp_options = wp_parse_args($swpsmtp_options, $swpsmtp_options_default);		
 
 	// Exit if password encrypted and openssl missing (possible?)
 	if ($swpsmtp_options['smtp_settings']['encrypt_pass'] === 1 && !extension_loaded('openssl')) {

--- a/uninstall.php
+++ b/uninstall.php
@@ -6,7 +6,8 @@ if (! defined('WP_UNINSTALL_PLUGIN')){
 
 // Options to remove
 $options = array(
-    'azrcrv-smtp'
+    'azrcrv-smtp',
+    'azrcrv-smtp-imported',
 );
 
 // Remove from single site

--- a/uninstall.php
+++ b/uninstall.php
@@ -7,7 +7,7 @@ if (! defined('WP_UNINSTALL_PLUGIN')){
 // Options to remove
 $options = array(
     'azrcrv-smtp',
-    'azrcrv-smtp-imported',
+    'azrcrv-smtp-maybe',
 );
 
 // Remove from single site


### PR DESCRIPTION
When activating the plugin if there are no settings for SMTP and there are from Easy WP SMTP the user is informed about and can import them. If they dismiss the notice no import is done.

Related to #2.

*If you notice an AJAX error in console when dismissing the notice, I've just opened an issue to the culprit :joy:*

![image](https://user-images.githubusercontent.com/29772709/108852118-7a046100-75e5-11eb-8403-7d1e0974a8a5.png)
