### PR TITLE
Add more information to failing test messages

### DIFF
--- a/azrcrv-smtp.php
+++ b/azrcrv-smtp.php
@@ -755,7 +755,7 @@ function azrcrv_smtp_send_test_email() {
 
 		$level                  = 2;
 		$phpmailer->SMTPDebug   = 1;
-		$phpmailer->Debugoutput = function( $str, $level ) use ( $error ) {
+		$phpmailer->Debugoutput = function( $str, $level ) use ( &$error ) {
 			$error .= $level . ': ' . $str . '\n';
 		};
 

--- a/azrcrv-smtp.php
+++ b/azrcrv-smtp.php
@@ -376,7 +376,7 @@ function azrcrv_smtp_display_options() {
 						<?php
 						$test_result = get_option( 'azrcrv-smtp-test' );
 						foreach ( $test_result as $error ) {
-							echo '<br />' . esc_html( $error );
+							echo '<br />' . wp_kses( $error, array ( 'br' => array(), 'hr' => array() ) );
 						}
 						?>
 					</p>
@@ -756,7 +756,7 @@ function azrcrv_smtp_send_test_email() {
 		$level                  = 2;
 		$phpmailer->SMTPDebug   = 1;
 		$phpmailer->Debugoutput = function( $str, $level ) use ( &$error ) {
-			$error .= $level . ': ' . $str . '\n';
+			$error .= $level . ': ' . $str . '<br />';
 		};
 
 		// Don't fail if the server is advertising TLS with an invalid certificate
@@ -770,7 +770,7 @@ function azrcrv_smtp_send_test_email() {
 		}
 
 		if ( strlen( $error ) > 0 ) {
-			$test_result[] = $error;
+			$test_result[] = '<hr>' . $error;
 		}
 
 		update_option( 'azrcrv-smtp-test', $test_result );


### PR DESCRIPTION
Before:
![Schermata 2022-04-09 alle 15 56 42 (1)](https://user-images.githubusercontent.com/29772709/162586234-efdd8c66-f4f4-4287-bde3-b59c1d7b3cc1.png)
After:
![Schermata 2022-04-09 alle 16 08 14](https://user-images.githubusercontent.com/29772709/162586260-37b436fe-8c6e-4c90-a10b-38a785321361.png)

