### PR TITLE
Fix Update Manager `View Details` link 

### DIFF
--- a/azrcrv-smtp.php
+++ b/azrcrv-smtp.php
@@ -35,6 +35,7 @@ const PLUGIN_SHORT_SLUG = 'smtp';
 const PLUGIN_SLUG       = 'azrcrv-' . PLUGIN_SHORT_SLUG;
 const PLUGIN_HYPHEN     = 'azrcrv-smtp';
 const PLUGIN_UNDERSCORE = 'azrcrv_smtp';
+const PLUGIN_FILE       = __FILE__;
 
 /**
  * Prevent direct access.

--- a/includes/functions-plugin-images.php
+++ b/includes/functions-plugin-images.php
@@ -17,7 +17,7 @@ namespace azurecurve\SMTP;
  */
 function custom_image_path( $path ) {
 	if ( strpos( $path, PLUGIN_SLUG ) !== false ) {
-		$path = plugin_dir_path( __FILE__ ) . '../assets/images';
+		$path = plugin_dir_path( PLUGIN_FILE ) . 'assets/images';
 	}
 	return $path;
 }
@@ -29,7 +29,7 @@ function custom_image_path( $path ) {
  */
 function custom_image_url( $url ) {
 	if ( strpos( $url, PLUGIN_SLUG ) !== false ) {
-		$url = esc_url_raw( plugin_dir_url( __FILE__ ) . '../assets/images' );
+		$url = esc_url_raw( plugin_dir_url( PLUGIN_FILE ) . 'assets/images' );
 	}
 	return $url;
 }

--- a/includes/functions-plugin-images.php
+++ b/includes/functions-plugin-images.php
@@ -16,10 +16,7 @@ namespace azurecurve\SMTP;
  * @since 1.2.0
  */
 function custom_image_path( $path ) {
-	if ( strpos( $path, PLUGIN_SLUG ) !== false ) {
-		$path = plugin_dir_path( PLUGIN_FILE ) . 'assets/images';
-	}
-	return $path;
+	return plugin_dir_path( PLUGIN_FILE ) . 'assets/images';
 }
 
 /**
@@ -28,8 +25,5 @@ function custom_image_path( $path ) {
  * @since 1.2.0
  */
 function custom_image_url( $url ) {
-	if ( strpos( $url, PLUGIN_SLUG ) !== false ) {
-		$url = esc_url_raw( plugin_dir_url( PLUGIN_FILE ) . 'assets/images' );
-	}
-	return $url;
+	return esc_url_raw( plugin_dir_url( PLUGIN_FILE ) . 'assets/images' );
 }

--- a/includes/setup.php
+++ b/includes/setup.php
@@ -33,5 +33,7 @@ add_action( 'phpmailer_init', __NAMESPACE__ . '\\send_smtp_email' );
 
 // add filters.
 add_filter( 'plugin_action_links', __NAMESPACE__ . '\\add_plugin_action_link', 10, 2 );
-add_filter( 'codepotent_update_manager_image_path', __NAMESPACE__ . '\\custom_image_path' );
-add_filter( 'codepotent_update_manager_image_url', __NAMESPACE__ . '\\custom_image_url' );
+
+$plugin_slug_for_um = plugin_basename( trim( PLUGIN_FILE ) );
+add_filter( 'codepotent_update_manager_' . $plugin_slug_for_um . '_image_path', __NAMESPACE__ . '\\custom_image_path' );
+add_filter( 'codepotent_update_manager_' . $plugin_slug_for_um . '_image_url', __NAMESPACE__ . '\\custom_image_url' );


### PR DESCRIPTION
I've made this PR in two commit:
- the first solves the problem in this [issue](https://github.com/xxsimoxx/codepotent-update-manager/issues/72)
- the second replaces the deprecated `codepotent_update_manager_image_path` and  `codepotent_update_manager_image_url` with `codepotent_update_manager_{plugin-slug}_image_path` and `codepotent_update_manager_{plugin-slug}_image_url`.